### PR TITLE
Implement Issue/PR Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Something is occurring that I think is wrong
+title: ''
+labels: "\U0001F41B bug"
+assignees: ''
+
+---
+
+## What is the current behavior?
+<!--
+What's happening that seems wrong?
+-->
+
+
+## Steps to reproduce
+<!--
+To make it faster to diagnose the root problem. Tell us how can we reproduce the bug.
+-->
+
+
+## Expected behavior
+<!--
+What would you expect to happen when following the steps above?
+-->
+
+
+## Please tell us about your environment
+<!--
+We want to make sure the problem isn't specific to your operating system or programming language.
+  
+- **Operating System/Version:** (ex. MacOS 14.2, Windows 10, RHEL 6, etc)
+- **Go Version:** (ex. v1.18)
+-->
+
+
+## Other information
+<!--
+Anything else we should know? (e.g. detailed explanation, stack-traces, related issues, suggestions how to fix, links for us to have context, eg. stack overflow, codepen, etc)
+-->
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Deepgram Developer Community
+    url: https://github.com/orgs/deepgram/discussions
+  - name: Deepgram on Twitter
+    url: https://twitter.com/DeepgramAI

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: I think X would be a cool addition or change.
+title: ''
+labels: "✨ enhancement"
+assignees: ''
+
+---
+
+## Proposed changes
+<!--
+Provide a detailed description of the change or addition you are proposing
+-->
+
+
+## Context
+<!--
+Why is this change important to you? How would you use it? How can it benefit other users?
+-->
+
+
+## Possible Implementation
+<!--
+Not obligatory, but suggest an idea for implementing addition or change
+-->
+
+
+## Other information
+<!--
+Anything else we should know? (e.g. detailed explanation, related issues, links for us to have context, eg. stack overflow, codepen, etc)
+-->
+
+

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,31 @@
+## Proposed changes
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+-->
+
+
+## Types of changes
+
+What types of changes does your code introduce to the community Python SDK?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update or tests (if none of the other choices apply)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
+- [ ] I have lint'ed all of my code using repo standards
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+
+## Further comments
+<!--
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+-->
+
+


### PR DESCRIPTION
This is copied over from:
https://github.com/deepgram/deepgram-python-sdk

This allows the ability to create Issues/PRs without the instructions making it's way into the Issue/PR.
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Documentation: Introduced new templates for GitHub issues and pull requests to streamline the process of reporting bugs, requesting features, and proposing changes. This will enhance communication and collaboration by providing a structured format for contributors.
- Chore: Added a configuration file to customize the issue creation interface on GitHub, improving user experience by providing direct contact links and disabling blank issues.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->